### PR TITLE
Change property types to use scalar types for the return values

### DIFF
--- a/property_types/energy.hpp
+++ b/property_types/energy.hpp
@@ -15,8 +15,6 @@ namespace property_types {
  */
 template<typename ElementType = double>
 struct Energy : public sde::PropertyType<Energy<ElementType>> {
-    /// The type of the energy derivative, accounting for ElementType
-    using tensor_type = type::tensor<ElementType>;
     /// Generates the input fields required by this property type
     auto inputs_();
     /// Generates the result fields required by this property type
@@ -36,7 +34,7 @@ auto Energy<ElementType>::inputs_() {
 
 template<typename ElementType>
 auto Energy<ElementType>::results_() {
-    auto rv = sde::declare_result().add_field<tensor_type>("Energy");
+    auto rv = sde::declare_result().add_field<ElementType>("Energy");
     rv["Energy"].set_description("The computed energy or derivatives");
     return rv;
 }

--- a/property_types/reference_wavefunction.hpp
+++ b/property_types/reference_wavefunction.hpp
@@ -40,7 +40,7 @@ auto ReferenceWavefunction<ElementType>::inputs_() {
 template<typename ElementType>
 auto ReferenceWavefunction<ElementType>::results_() {
     auto rv = sde::declare_result()
-                .add_field<tensor_type>("Energy")
+                .add_field<ElementType>("Energy")
                 .template add_field<orbital_type>("Orbital Space");
     rv["Energy"].set_description("The computed energy or derivatives");
     rv["Orbital Space"].set_description("The reference wavefunction");

--- a/property_types/scf_iteration.hpp
+++ b/property_types/scf_iteration.hpp
@@ -48,7 +48,7 @@ template<typename ElementType>
 auto SCFIteration<ElementType>::results_() {
     auto rv = sde::declare_result()
                 .add_field<tensor_type>("Fock Matrix")
-                .template add_field<tensor_type>("Electronic Energy");
+                .template add_field<ElementType>("Electronic Energy");
     rv["Fock Matrix"].set_description("The computed Fock Matrix");
     rv["Electronic Energy"].set_description("The computed electronic energy");
     return rv;

--- a/property_types/xc_quantities.hpp
+++ b/property_types/xc_quantities.hpp
@@ -115,7 +115,7 @@ template<typename ElementType>
 auto PureXCQuantities<ElementType>::results_() {
     auto rv = sde::declare_result()
                 .add_field<tensor_type>("VXC Matrix")
-                .template add_field<tensor_type>("EXC Energy");
+                .template add_field<ElementType>("EXC Energy");
     rv["VXC Matrix"].set_description("The computed VXC Matrix");
     rv["EXC Energy"].set_description("The computed EXC Energy");
     return rv;
@@ -125,8 +125,8 @@ template<typename ElementType>
 auto HybridXCQuantities<ElementType>::results_() {
     auto rv = sde::declare_result()
                 .add_field<tensor_type>("VXC Matrix")
-                .template add_field<tensor_type>("EXC Energy")
-                .template add_field<tensor_type>("xEXX");
+                .template add_field<ElementType>("EXC Energy")
+                .template add_field<ElementType>("xEXX");
     rv["VXC Matrix"].set_description("The computed VXC Matrix");
     rv["EXC Energy"].set_description("The computed EXC Energy");
     rv["xEXX"].set_description("Scaled HF Exchange Energy Contribution");
@@ -137,9 +137,9 @@ template<typename ElementType>
 auto DoubleHybridXCQuantities<ElementType>::results_() {
     auto rv = sde::declare_result()
                 .add_field<tensor_type>("VXC Matrix")
-                .template add_field<tensor_type>("EXC Energy")
-                .template add_field<tensor_type>("xEXX")
-                .template add_field<tensor_type>("xEMP2");
+                .template add_field<ElementType>("EXC Energy")
+                .template add_field<ElementType>("xEXX")
+                .template add_field<ElementType>("xEMP2");
     rv["VXC Matrix"].set_description("The computed VXC Matrix");
     rv["EXC Energy"].set_description("The computed EXC Energy");
     rv["xEXX"].set_description("Scaled HF Exchange Energy Contribution");


### PR DESCRIPTION
We previously were returning tensor objects for things like an SCF energy, but it seems like it will be easier and cleaner to just return e.g. doubles.