### PR TITLE
Another SCF Fix...

### DIFF
--- a/include/property_types/scf_iteration.hpp
+++ b/include/property_types/scf_iteration.hpp
@@ -46,10 +46,11 @@ auto SCFIteration<ElementType, OrbitalType>::inputs_() {
 
 template<typename ElementType, typename OrbitalType>
 auto SCFIteration<ElementType, OrbitalType>::results_() {
-    auto rv = sde::declare_result()
-                .add_field<tensor_type>("Fock Matrix")
+    auto key = "(m|f|n)";
+    auto rv  = sde::declare_result()
+                .add_field<tensor_type>(key)
                 .template add_field<ElementType>("Electronic Energy");
-    rv["Fock Matrix"].set_description("The computed Fock Matrix");
+    rv[key].set_description("The computed Fock Matrix");
     rv["Electronic Energy"].set_description("The computed electronic energy");
     return rv;
 }

--- a/tests/scf_iteration.cpp
+++ b/tests/scf_iteration.cpp
@@ -4,5 +4,5 @@
 TEST_CASE("SCFIteration") {
     test_property_type<property_types::SCFIteration<>>(
       {"Molecule", "Molecular Orbitals", "bra", "ket"},
-      {"Fock Matrix", "Electronic Energy"});
+      {"(m|f|n)", "Electronic Energy"});
 }


### PR DESCRIPTION
This PR should fix the last error in SCF. Basically because the SCF iteration property type is currently coupled to the Fock matrix property type things need to change in multiple places. At some point the SCF iteration property type should really be two property types: one for the matrix and one for energy contribution. Should be r2g.