### PR TITLE
adds fragmented pt

### DIFF
--- a/include/property_types/fragmented.hpp
+++ b/include/property_types/fragmented.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include <libchemist/set_theory/set_theory.hpp>
+#include <sde/sde.hpp>
+
+namespace property_types {
+
+/** @brief Property type for requesting that an object be Fragmented
+ *
+ *  Chemistry concepts such as functional groups, polymers, coordination
+ *  compounds, etc. are predicated on the idea that we can understand the
+ *  chemistry of large systems by understanding the chemistry of the system's
+ *  parts. That said there are a lot of different ways to "fragment" a system
+ *  (for a molecule with @f$n@f$ atoms there are @f$B_n@f$ partitions where
+ *  @f$B_n@f$ is the @f$n@f$-th Bell number). In practice the fragmenting is
+ *  usually not arbitrary, but the result of some algorithm which relies on
+ *  chemical concepts such as bonds and/or spatial distances to assign the
+ *  fragments. Nonetheless, there are still a large number of algorithms and
+ *  this property type is for any module which fragments an object into
+ *  subobjects. Examples are:
+ *  - `Fragmented<Molecule>` for fragmenting a molecular system
+ *  - `Fragmented<AOBasisSet<double>>` for fragmenting basis sets
+ *
+ *  @tparam Type2Fragment The object type we are fragmenting. Expected to be
+ *                        set-like although exactly what the module does with
+ *                        the type is up to the module.
+ */
+
+template<typename Type2Fragment>
+DECLARE_TEMPLATED_PROPERTY_TYPE(Fragmented, Type2Fragment);
+
+template<typename Type2Fragment>
+PROPERTY_TYPE_INPUTS(Fragmented<Type2Fragment>) {
+    return sde::declare_input().add_field<Type2Fragment>("Object to Fragment");
+}
+
+template<typename Type2Fragment>
+PROPERTY_TYPE_RESULTS(Fragmented<Type2Fragment>) {
+    using return_type = libchemist::set_theory::FamilyOfSets<Type2Fragment>;
+    return sde::declare_result().add_field<return_type>("Fragmented Object");
+}
+
+} // namespace property_types

--- a/tests/fragmented.cpp
+++ b/tests/fragmented.cpp
@@ -1,0 +1,13 @@
+#include "property_types/fragmented.hpp"
+#include "property_types/types.hpp"
+#include "test_property_type.hpp"
+
+using namespace property_types;
+
+using tuple = std::tuple<type::molecule>;
+
+TEMPLATE_LIST_TEST_CASE("Fragmented", "", tuple) {
+    using T = TestType;
+    test_property_type<Fragmented<T>>({"Object to Fragment"},
+                                      {"Fragmented Object"});
+}


### PR DESCRIPTION
Adds the `Fragmented` property type for modules which fragment objects (here fragmenting just means breaking things into subsets).

This PR is r2g after:
 - [ ] merge NWChemEx-Project/LibChemist#195