### PR TITLE
AtomToAO Fix

### DIFF
--- a/include/simde/atom_to_ao.hpp
+++ b/include/simde/atom_to_ao.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "simde/types.hpp"
+#include <pluginplay/property_type/property_type.hpp>
 
 namespace simde {
 namespace detail_ {

--- a/tests/simde/atom_to_ao.cpp
+++ b/tests/simde/atom_to_ao.cpp
@@ -1,0 +1,7 @@
+#include "simde/atom_to_ao.hpp"
+#include "test_property_type.hpp"
+
+TEST_CASE("AtomToCenter") {
+    test_property_type<simde::AtomToAO>({"Molecule", "Orbital Basis"},
+                                        {"Atom to Center map"});
+}


### PR DESCRIPTION
Adds missing header to `atom_to_ao.hpp`, along with a test for the associated ptype.