### PR TITLE
Adds AtomicOrbitals PT

### DIFF
--- a/include/simde/orbital_spaces/atomic_orbitals.hpp
+++ b/include/simde/orbital_spaces/atomic_orbitals.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include <pluginplay/property_type/property_type.hpp>
+#include <simde/types.hpp>
+
+namespace simde {
+
+/** @brief PT for going from a set of nuclei to a set of point-center orbitals.
+ *
+ *  Modules which take a set of nuclei and return a set of point-centered
+ *  (in general they will be atom-centered, but in theory there could be
+ *  mid-bond functions or something) are said to obey the AtomicOrbitals PT.
+ *
+ *  Examples of algorithms that could fall under this PT are:
+ *
+ *  - The usual AO basis formation (i.e., looking up hard-coded parameters for
+ *    a specific atomic number and taking the union of the translated orbitals)
+ *  - Computing mid-bond functions
+ *  - User-specified bases via lambda modules
+ *  - Opaque processing of an assigned set of AOs (e.g., nesting
+ *    AtomicOrbitals modules so that the inner one forms the usual AO basis and
+ *    the latter prunes diffuse functions or something)
+ */
+DECLARE_PROPERTY_TYPE(AtomicOrbitals);
+
+PROPERTY_TYPE_INPUTS(AtomicOrbitals) {
+    using mol_t = const type::molecule&;
+    auto rv     = pluginplay::declare_input().add_field<mol_t>("Nuclei");
+    return rv;
+}
+
+PROPERTY_TYPE_RESULTS(AtomicOrbitals) {
+    using aos_t = type::ao_space;
+    auto rv = pluginplay::declare_result().add_field<aos_t>("Atomic Orbitals");
+    return rv;
+}
+
+} // namespace simde

--- a/include/simde/orbital_spaces/orbital_spaces.hpp
+++ b/include/simde/orbital_spaces/orbital_spaces.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "simde/orbital_spaces/atomic_orbitals.hpp"
 #include "simde/orbital_spaces/auxiliary_basis_set.hpp"
 #include "simde/orbital_spaces/complimentary_auxiliary_basis_set.hpp"
 #include "simde/orbital_spaces/density_fit_basis.hpp"


### PR DESCRIPTION
AFAIK the only way to assign AOs to nuclei is with the `apply_basis` function. This PR adds a PT `AtomicOrbitals` so that we can write modules to do this for us. This PR is r2g.