### PR TITLE
Removes "private" from Chemist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ cmaize_option_list(
 cmaize_find_or_build_dependency(
     chemist
     URL github.com/NWChemEx/chemist
-    PRIVATE TRUE
     VERSION ${NWX_CHEMIST_VERSION}
     BUILD_TARGET chemist
     FIND_TARGET nwx::chemist


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
Chemist is now a public repo and does not require the GitHub token to be set. This PR updates the CMakeLists.txt to fix this.

**TODOs**
None. r2g.
