### PR TITLE
Provisional Derivative Property Types

### DIFF
--- a/include/simde/derivative/nuclear.hpp
+++ b/include/simde/derivative/nuclear.hpp
@@ -17,53 +17,59 @@
 #include <chemist/chemist.hpp>
 #include <simde/derivative/derivative_pt.hpp>
 #include <simde/energy/ao_energy.hpp>
+#include <simde/energy/total_energy.hpp>
 
 namespace simde {
 
+/** @brief Property type which computes the derivative with respect to nuclear
+ *         positions.
+ *
+ *  @tparam PropertyType The property type we are taking the derivitive of.
+ *  @tparam TensorType The type the gradient is returned as.
+ */
 template<typename PropertyType, typename TensorType>
 using NuclearDerivative =
   Derivative<PropertyType, chemist::PointSet<double>, TensorType>;
 
+/** @brief Specializes NuclearDerivative to when PropertyType == TotalEnergy
+ *
+ *  @tparam TensorType The type the gradient is returned as.
+ */
+template<typename TensorType>
+using EnergyNuclearGradient = NuclearDerivative<TotalEnergy, TensorType>;
+
+/** @brief Specializes NuclearDerivative to Hessians of TotalEnergy
+ *
+ *  @tparam TensorType The type the Hessian is returned as.
+ */
+template<typename TensorType>
+using EnergyNuclearHessian =
+  NuclearDerivative<EnergyNuclearGradient<TensorType>, TensorType>;
+
+/** @brief Specializes NuclearDerivative to Gradients of AOEnergy
+ *
+ *  @tparam TensorType The type of the gradient
+ */
 template<typename TensorType>
 using AOEnergyNuclearGradient = NuclearDerivative<AOEnergy, TensorType>;
 
+/** @brief Specializes NuclearDerivative to Hessians of AOEnergy
+ *
+ *  @tparam TensorType The type of the gradient
+ */
 template<typename TensorType>
 using AOEnergyNuclearHessian =
   NuclearDerivative<AOEnergyNuclearGradient<TensorType>, TensorType>;
 
-namespace provisional {
+// --  Assumes tensors are stored as std::vector objects
+using EnergyNuclearGradientStdVectorD =
+  EnergyNuclearGradient<std::vector<double>>;
 
-// These typedefs are not yet part of the official API and are subject to change
-using AOEnergyNuclearGradientD = AOEnergyNuclearGradient<std::vector<double>>;
-using AOEnergyNuclearHessianD  = AOEnergyNuclearHessian<std::vector<double>>;
-
-/** @brief The property type for modules that compute an energy gradient for a
- *         chemical system.
- *
- * Analogous interface as TotalEnergy
- */
-template<typename TensorType>
-DECLARE_TEMPLATED_PROPERTY_TYPE(EnergyNuclearGradient, TensorType);
-
-template<typename TensorType>
-TEMPLATED_PROPERTY_TYPE_INPUTS(EnergyNuclearGradient, TensorType) {
-    using chem_sys_t = const type::chemical_system&;
-    auto rv =
-      pluginplay::declare_input().add_field<chem_sys_t>("Chemical System");
-    rv["Chemical System"].set_description("The chemical system");
-    return rv;
-}
-
-template<typename TensorType>
-TEMPLATED_PROPERTY_TYPE_RESULTS(EnergyNuclearGradient, TensorType) {
-    auto rv =
-      pluginplay::declare_result().template add_field<TensorType>("Derivative");
-    rv["Derivative"].set_description("The computed derivative");
-    return rv;
-}
-
-using EnergyNuclearGradientD = EnergyNuclearGradient<std::vector<double>>;
-
-} // namespace provisional
+using EnergyNuclearHessianStdVectorD =
+  EnergyNuclearHessian<std::vector<double>>;
+using AOEnergyNuclearGradientStdVectorD =
+  AOEnergyNuclearGradient<std::vector<double>>;
+using AOEnergyNuclearHessianStdVectorD =
+  AOEnergyNuclearHessian<std::vector<double>>;
 
 } // namespace simde

--- a/include/simde/derivative/nuclear.hpp
+++ b/include/simde/derivative/nuclear.hpp
@@ -39,7 +39,7 @@ using AOEnergyNuclearHessianD  = AOEnergyNuclearHessian<std::vector<double>>;
 
 /** @brief The property type for modules that compute an energy gradient for a
  *         chemical system.
- * 
+ *
  * Analogous interface as TotalEnergy
  */
 template<typename TensorType>
@@ -56,8 +56,8 @@ TEMPLATED_PROPERTY_TYPE_INPUTS(EnergyNuclearGradient, TensorType) {
 
 template<typename TensorType>
 TEMPLATED_PROPERTY_TYPE_RESULTS(EnergyNuclearGradient, TensorType) {
-    auto rv = pluginplay::declare_result().template add_field<TensorType>(
-      "Derivative");
+    auto rv =
+      pluginplay::declare_result().template add_field<TensorType>("Derivative");
     rv["Derivative"].set_description("The computed derivative");
     return rv;
 }

--- a/include/simde/derivative/nuclear.hpp
+++ b/include/simde/derivative/nuclear.hpp
@@ -31,4 +31,12 @@ template<typename TensorType>
 using AOEnergyNuclearHessian =
   NuclearDerivative<AOEnergyNuclearGradient<TensorType>, TensorType>;
 
+// These typedefs are not yet part of the official API and are subject to change
+namespace provisional {
+
+using AOEnergyNuclearGradientD = AOEnergyNuclearGradient<std::vector<double>>;
+using AOEnergyNuclearHessianD  = AOEnergyNuclearHessian<std::vector<double>>;
+
+} // namespace provisional
+
 } // namespace simde

--- a/include/simde/derivative/nuclear.hpp
+++ b/include/simde/derivative/nuclear.hpp
@@ -31,11 +31,38 @@ template<typename TensorType>
 using AOEnergyNuclearHessian =
   NuclearDerivative<AOEnergyNuclearGradient<TensorType>, TensorType>;
 
-// These typedefs are not yet part of the official API and are subject to change
 namespace provisional {
 
+// These typedefs are not yet part of the official API and are subject to change
 using AOEnergyNuclearGradientD = AOEnergyNuclearGradient<std::vector<double>>;
 using AOEnergyNuclearHessianD  = AOEnergyNuclearHessian<std::vector<double>>;
+
+/** @brief The property type for modules that compute an energy gradient for a
+ *         chemical system.
+ * 
+ * Analogous interface as TotalEnergy
+ */
+template<typename TensorType>
+DECLARE_TEMPLATED_PROPERTY_TYPE(EnergyNuclearGradient, TensorType);
+
+template<typename TensorType>
+TEMPLATED_PROPERTY_TYPE_INPUTS(EnergyNuclearGradient, TensorType) {
+    using chem_sys_t = const type::chemical_system&;
+    auto rv =
+      pluginplay::declare_input().add_field<chem_sys_t>("Chemical System");
+    rv["Chemical System"].set_description("The chemical system");
+    return rv;
+}
+
+template<typename TensorType>
+TEMPLATED_PROPERTY_TYPE_RESULTS(EnergyNuclearGradient, TensorType) {
+    auto rv = pluginplay::declare_result().template add_field<TensorType>(
+      "Derivative");
+    rv["Derivative"].set_description("The computed derivative");
+    return rv;
+}
+
+using EnergyNuclearGradientD = EnergyNuclearGradient<std::vector<double>>;
 
 } // namespace provisional
 

--- a/src/python/derivative/export_derivative.hpp
+++ b/src/python/derivative/export_derivative.hpp
@@ -21,14 +21,11 @@
 
 namespace simde {
 
-namespace provisional {
-
 inline void export_derivative(python_module_reference m) {
-    EXPORT_PROPERTY_TYPE(AOEnergyNuclearGradientD, m);
-    EXPORT_PROPERTY_TYPE(AOEnergyNuclearHessianD, m);
-    EXPORT_PROPERTY_TYPE(EnergyNuclearGradientD, m);
+    EXPORT_PROPERTY_TYPE(EnergyNuclearGradientStdVectorD, m);
+    EXPORT_PROPERTY_TYPE(EnergyNuclearHessianStdVectorD, m);
+    EXPORT_PROPERTY_TYPE(AOEnergyNuclearGradientStdVectorD, m);
+    EXPORT_PROPERTY_TYPE(AOEnergyNuclearHessianStdVectorD, m);
 }
-
-} // namespace provisional
 
 } // namespace simde

--- a/src/python/derivative/export_derivative.hpp
+++ b/src/python/derivative/export_derivative.hpp
@@ -14,24 +14,20 @@
  * limitations under the License.
  */
 
-#include "basis_set/export_basis_set.hpp"
-#include "chemical_system/export_chemical_system.hpp"
-#include "derivative/export_derivative.hpp"
-#include "energy/export_energy.hpp"
-#include "export_simde.hpp"
+#pragma once
+#include "../export_simde.hpp"
+#include <pluginplay/pluginplay.hpp>
+#include <simde/derivative/derivative.hpp>
 
 namespace simde {
 
-PYBIND11_MODULE(simde, m) {
-    m.doc() =
-      "PySimDE: Python bindings for the Simulation development environment";
-    export_chemical_system(m);
-    export_basis_set(m);
-    export_energy(m);
+namespace provisional {
 
-    // Submodule for 
-    auto m_provisional = m.def_submodule("provisional");
-    provisional::export_derivative(m_provisional);
+inline void export_derivative(python_module_reference m) {
+    EXPORT_PROPERTY_TYPE(AOEnergyNuclearGradientD, m);
+    EXPORT_PROPERTY_TYPE(AOEnergyNuclearHessianD, m);
 }
+
+} // namespace provisional
 
 } // namespace simde

--- a/src/python/derivative/export_derivative.hpp
+++ b/src/python/derivative/export_derivative.hpp
@@ -26,6 +26,7 @@ namespace provisional {
 inline void export_derivative(python_module_reference m) {
     EXPORT_PROPERTY_TYPE(AOEnergyNuclearGradientD, m);
     EXPORT_PROPERTY_TYPE(AOEnergyNuclearHessianD, m);
+    EXPORT_PROPERTY_TYPE(EnergyNuclearGradientD, m);
 }
 
 } // namespace provisional

--- a/src/python/module.cpp
+++ b/src/python/module.cpp
@@ -28,10 +28,7 @@ PYBIND11_MODULE(simde, m) {
     export_chemical_system(m);
     export_basis_set(m);
     export_energy(m);
-
-    // Submodule for
-    auto m_provisional = m.def_submodule("provisional");
-    provisional::export_derivative(m_provisional);
+    export_derivative(m);
 }
 
 } // namespace simde

--- a/src/python/module.cpp
+++ b/src/python/module.cpp
@@ -29,7 +29,7 @@ PYBIND11_MODULE(simde, m) {
     export_basis_set(m);
     export_energy(m);
 
-    // Submodule for 
+    // Submodule for
     auto m_provisional = m.def_submodule("provisional");
     provisional::export_derivative(m_provisional);
 }

--- a/tests/cxx/unit_tests/derivative/nuclear.cpp
+++ b/tests/cxx/unit_tests/derivative/nuclear.cpp
@@ -19,8 +19,8 @@
 #include <simde/energy/ao_energy.hpp>
 #include <vector>
 
-using Gradient = simde::AOEnergyNuclearGradient<std::vector<double>>;
-using Hessian  = simde::AOEnergyNuclearHessian<std::vector<double>>;
+using Gradient = simde::provisional::AOEnergyNuclearGradientD;
+using Hessian  = simde::provisional::AOEnergyNuclearHessianD;
 
 TEST_CASE("Nuclear Derivative Property Types") {
     test_property_type<Gradient>({"AOs", "Chemical System", "Arg 1"},

--- a/tests/cxx/unit_tests/derivative/nuclear.cpp
+++ b/tests/cxx/unit_tests/derivative/nuclear.cpp
@@ -25,11 +25,12 @@ using AOGradient = simde::AOEnergyNuclearGradientStdVectorD;
 using AOHessian  = simde::AOEnergyNuclearHessianStdVectorD;
 
 TEST_CASE("Nuclear Derivative Property Types") {
+    test_property_type<Gradient>({"Chemical System", "Arg 1"}, {"Derivative"});
+    test_property_type<Hessian>({"Chemical System", "Arg 1", "Arg2"},
+                                {"Derivative"});
     test_property_type<AOGradient>({"AOs", "Chemical System", "Arg 1"},
                                    {"Derivative"});
 
     test_property_type<AOHessian>({"AOs", "Chemical System", "Arg 1", "Arg 2"},
                                   {"Derivative"});
-
-    test_property_type<Gradient>({"Chemical System"}, {"Derivative"});
 }

--- a/tests/cxx/unit_tests/derivative/nuclear.cpp
+++ b/tests/cxx/unit_tests/derivative/nuclear.cpp
@@ -19,13 +19,16 @@
 #include <simde/energy/ao_energy.hpp>
 #include <vector>
 
-using Gradient = simde::provisional::AOEnergyNuclearGradientD;
-using Hessian  = simde::provisional::AOEnergyNuclearHessianD;
+using AOGradient = simde::provisional::AOEnergyNuclearGradientD;
+using AOHessian  = simde::provisional::AOEnergyNuclearHessianD;
+using Gradient   = simde::provisional::EnergyNuclearGradientD;
 
 TEST_CASE("Nuclear Derivative Property Types") {
-    test_property_type<Gradient>({"AOs", "Chemical System", "Arg 1"},
-                                 {"Derivative"});
+    test_property_type<AOGradient>({"AOs", "Chemical System", "Arg 1"},
+                                   {"Derivative"});
 
-    test_property_type<Hessian>({"AOs", "Chemical System", "Arg 1", "Arg 2"},
-                                {"Derivative"});
+    test_property_type<AOHessian>({"AOs", "Chemical System", "Arg 1", "Arg 2"},
+                                  {"Derivative"});
+
+    test_property_type<Gradient>({"Chemical System"}, {"Derivative"});
 }

--- a/tests/cxx/unit_tests/derivative/nuclear.cpp
+++ b/tests/cxx/unit_tests/derivative/nuclear.cpp
@@ -19,9 +19,10 @@
 #include <simde/energy/ao_energy.hpp>
 #include <vector>
 
-using AOGradient = simde::provisional::AOEnergyNuclearGradientD;
-using AOHessian  = simde::provisional::AOEnergyNuclearHessianD;
-using Gradient   = simde::provisional::EnergyNuclearGradientD;
+using Gradient   = simde::EnergyNuclearGradientStdVectorD;
+using Hessian    = simde::EnergyNuclearHessianStdVectorD;
+using AOGradient = simde::AOEnergyNuclearGradientStdVectorD;
+using AOHessian  = simde::AOEnergyNuclearHessianStdVectorD;
 
 TEST_CASE("Nuclear Derivative Property Types") {
     test_property_type<AOGradient>({"AOs", "Chemical System", "Arg 1"},

--- a/tests/python/unit_tests/derivative/__init__.py
+++ b/tests/python/unit_tests/derivative/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/python/unit_tests/derivative/test_derivative.py
+++ b/tests/python/unit_tests/derivative/test_derivative.py
@@ -31,6 +31,7 @@ class TestAOEnergyNuclearHessianD(BaseTestPropertyType):
         self.input_labels = ["AOs", "Chemical System", "Arg 1", "Arg 2"]
         self.result_labels = ["Derivative"]
 
+
 class TestEnergyNuclearGradientD(BaseTestPropertyType):
 
     def setUp(self):

--- a/tests/python/unit_tests/derivative/test_derivative.py
+++ b/tests/python/unit_tests/derivative/test_derivative.py
@@ -1,0 +1,32 @@
+# Copyright 2023 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import simde
+from test_property_type import BaseTestPropertyType
+
+
+class TestAOEnergyNuclearGradientD(BaseTestPropertyType):
+
+    def setUp(self):
+        self.pt = simde.provisional.AOEnergyNuclearGradientD()
+        self.input_labels = ["AOs", "Chemical System", "Arg 1"]
+        self.result_labels = ["Derivative"]
+
+
+class TestAOEnergyNuclearHessianD(BaseTestPropertyType):
+
+    def setUp(self):
+        self.pt = simde.provisional.AOEnergyNuclearHessianD()
+        self.input_labels = ["AOs", "Chemical System", "Arg 1", "Arg 2"]
+        self.result_labels = ["Derivative"]

--- a/tests/python/unit_tests/derivative/test_derivative.py
+++ b/tests/python/unit_tests/derivative/test_derivative.py
@@ -30,3 +30,10 @@ class TestAOEnergyNuclearHessianD(BaseTestPropertyType):
         self.pt = simde.provisional.AOEnergyNuclearHessianD()
         self.input_labels = ["AOs", "Chemical System", "Arg 1", "Arg 2"]
         self.result_labels = ["Derivative"]
+
+class TestEnergyNuclearGradientD(BaseTestPropertyType):
+
+    def setUp(self):
+        self.pt = simde.provisional.EnergyNuclearGradientD()
+        self.input_labels = ["Chemical System"]
+        self.result_labels = ["Derivative"]

--- a/tests/python/unit_tests/derivative/test_derivative.py
+++ b/tests/python/unit_tests/derivative/test_derivative.py
@@ -16,25 +16,33 @@ import simde
 from test_property_type import BaseTestPropertyType
 
 
-class TestAOEnergyNuclearGradientD(BaseTestPropertyType):
+class TestEnergyNuclearGradientStdVectorD(BaseTestPropertyType):
 
     def setUp(self):
-        self.pt = simde.provisional.AOEnergyNuclearGradientD()
+        self.pt = simde.EnergyNuclearGradientStdVectorD()
+        self.input_labels = ["Chemical System", "Arg 1"]
+        self.result_labels = ["Derivative"]
+
+
+class TestEnergyNuclearHessianStdVectorD(BaseTestPropertyType):
+
+    def setUp(self):
+        self.pt = simde.EnergyNuclearHessianStdVectorD()
+        self.input_labels = ["Chemical System", "Arg 1", "Arg 2"]
+        self.result_labels = ["Derivative"]
+
+
+class TestAOEnergyNuclearGradientStdVectorD(BaseTestPropertyType):
+
+    def setUp(self):
+        self.pt = simde.AOEnergyNuclearGradientStdVectorD()
         self.input_labels = ["AOs", "Chemical System", "Arg 1"]
         self.result_labels = ["Derivative"]
 
 
-class TestAOEnergyNuclearHessianD(BaseTestPropertyType):
+class TestAOEnergyNuclearHessianStdVectorD(BaseTestPropertyType):
 
     def setUp(self):
-        self.pt = simde.provisional.AOEnergyNuclearHessianD()
+        self.pt = simde.AOEnergyNuclearHessianStdVectorD()
         self.input_labels = ["AOs", "Chemical System", "Arg 1", "Arg 2"]
-        self.result_labels = ["Derivative"]
-
-
-class TestEnergyNuclearGradientD(BaseTestPropertyType):
-
-    def setUp(self):
-        self.pt = simde.provisional.EnergyNuclearGradientD()
-        self.input_labels = ["Chemical System"]
         self.result_labels = ["Derivative"]


### PR DESCRIPTION
**Description**
Introduces typedefs for gradients and hessians where the `TensorType` is `std::vector<double>`, primarily so that they can be exposed in Python. The new property types are added in a the namespace `provisional` to indicate that they aren't the intended final versions of those definitions.