### PR TITLE
Update Atomic Number Type

### DIFF
--- a/include/simde/types.hpp
+++ b/include/simde/types.hpp
@@ -39,7 +39,7 @@ using atom = typename molecule::atom_type;
 using atomic_symbol = typename atom::name_type;
 
 /// Typedef of the class which models an atomic number
-using atomic_number = typename atom::size_type;
+using atomic_number = typename atom::atomic_number_type;
 
 /// Typedef of the class which describes an entire chemical system
 using chemical_system = chemist::ChemicalSystem;


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
The exposed `atomic_number` type wasn't linked to the correct source of truth, but now should be.
