### PR TITLE
SCF Property Types

### DIFF
--- a/include/simde/simde.hpp
+++ b/include/simde/simde.hpp
@@ -20,3 +20,4 @@
 #include <simde/energy/energy.hpp>
 #include <simde/evaluate_braket/evaluate_braket.hpp>
 #include <simde/types.hpp>
+#include <simde/wavefunction/wavefunction.hpp>

--- a/include/simde/types.hpp
+++ b/include/simde/types.hpp
@@ -82,4 +82,7 @@ using aos_squared = chemist::dsl::Multiply<aos, aos>;
 /// Import the operator types
 using namespace chemist::qm_operator::types;
 
+/// Pull in the Hamiltonian operator in case-consistent manner
+using hamiltonian = chemist::qm_operator::Hamiltonian;
+
 } // namespace simde::type

--- a/include/simde/utils/convert.hpp
+++ b/include/simde/utils/convert.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <pluginplay/pluginplay.hpp>
+
+namespace simde {
+
+template<typename ToType, typename FromType>
+DECLARE_TEMPLATED_PROPERTY_TYPE(Convert, ToType, FromType);
+
+template<typename ToType, typename FromType>
+TEMPLATED_PROPERTY_TYPE_INPUTS(Convert, ToType, FromType) {
+    return PropertyType::inputs().template add_field<FromType>(
+      "Object to convert from");
+}
+
+template<typename ToType, typename FromType>
+TEMPLATED_PROPERTY_TYPE_Results(Convert, ToType, FromType) {
+    return pluginplay::declare_result().template add_field<ToType>(
+      "Converted object");
+}
+
+} // namespace simde

--- a/include/simde/wavefunction/initial_guess.hpp
+++ b/include/simde/wavefunction/initial_guess.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <pluginplay/pluginplay.hpp>
+#include <simde/types.hpp>
+
+namespace simde {
+
+template<typename ResultType>
+DECLARE_TEMPLATED_PROPERTY_TYPE(InitialGuess, ResultType);
+
+template<typename ResultType>
+TEMPLATED_PROPERTY_TYPE_INPUTS(InitialGuess, ResultType) {
+    using hamiltonian_type = const type::hamiltonian&;
+    using aos_type         = const type::aos&;
+    return PropertyType::inputs()
+      .template add_field<hamiltonian_type>("Hamiltonian")
+      .template add_field<aos_type>("AOs");
+}
+
+template<typename ResultType>
+TEMPLATED_PROPERTY_TYPE_RESULTS(InitialGuess, ResultType) {
+    return pluginplay::declare_result().template add_field<ResultType>(
+      "Initial Wavefunction");
+}
+
+} // namespace simde

--- a/include/simde/wavefunction/wavefunction.hpp
+++ b/include/simde/wavefunction/wavefunction.hpp
@@ -1,0 +1,2 @@
+#pragma once
+#include <simde/wavefunction/initial_guess.hpp>


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
The goal of this PR is to add the initial set of property types needed for the SCF. This includes:
- [x] `Convert` (needed to convert say the `ChemicalSystem` into a `Hamiltonian`
- [x] `InitialGuess` (name may need changed)
- [ ] `aos_e_density_aos`
- [ ] `FockOperator`
- [ ] `UpdateGuess`
- [ ] `ESCF<OrbitalType>`

**TODOs**
