### PR TITLE
PT for electrostatic interactions

### DIFF
--- a/include/simde/energy/electrostatic_energy.hpp
+++ b/include/simde/energy/electrostatic_energy.hpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <pluginplay/property_type/property_type.hpp>
+#include <simde/types.hpp>
+
+namespace simde {
+
+template<typename ObjectType, typename PotentialType>
+DECLARE_TEMPLATED_PROPERTY_TYPE(ElectrostaticEnergy, ObjectType, PotentialType);
+
+template<typename ObjectType, typename PotentialType>
+TEMPLATED_PROPERTY_TYPE_INPUTS(ElectrostaticEnergy, ObjectType, PotentialType) {
+    using object_type    = const ObjectType&;
+    using potential_type = const PotentialType&;
+    auto rv              = pluginplay::declare_input()
+                .add_field<object_type>("Objects")
+                .template add_field<potential_type>("Potential");
+    rv["Objects"].set_description("The objects interacting with the potential");
+    rv["Potential"].set_description(
+      "The electrostatic potential (or the objects generating the potential)");
+    return rv;
+}
+
+template<typename ObjectType, typename PotentialType>
+TEMPLATED_PROPERTY_TYPE_RESULTS(ElectrostaticEnergy, ObjectType,
+                                PotentialType) {
+    auto rv = pluginplay::declare_result().add_field<double>("Energy");
+    return rv;
+}
+
+using charge_charge_interaction =
+  ElectrostaticEnergy<type::charges, type::charges>;
+
+} // namespace simde

--- a/include/simde/energy/energy.hpp
+++ b/include/simde/energy/energy.hpp
@@ -22,4 +22,5 @@
 #pragma once
 
 #include <simde/energy/ao_energy.hpp>
+#include <simde/energy/electrostatic_energy.hpp>
 #include <simde/energy/total_energy.hpp>

--- a/include/simde/types.hpp
+++ b/include/simde/types.hpp
@@ -97,6 +97,9 @@ using aos = chemist::wavefunction::AOs;
 /// Typedef of the class used to represent a product of atomic orbital spaces
 using aos_squared = chemist::dsl::Multiply<aos, aos>;
 
+/// Typedef of the class used to represent transformed AOs
+using mos = chemist::wavefunction::MOs;
+
 /// Typedef of the class used to represent the space spanned by the canonical
 /// molecular orbitals
 using cmos = chemist::wavefunction::CMOs;

--- a/include/simde/types.hpp
+++ b/include/simde/types.hpp
@@ -33,6 +33,9 @@ using tensor = tensorwrapper::Tensor;
 
 // --------------------- Fundamental Types -------------------------------------
 
+/// Typedef of the class used to hold a set of point charges
+using charges = chemist::Charges<double>;
+
 /// Typedef of the class used to describe an electron
 using electron = chemist::Electron;
 

--- a/tests/cxx/unit_tests/energy/energy.cpp
+++ b/tests/cxx/unit_tests/energy/energy.cpp
@@ -15,10 +15,19 @@
  */
 
 #include "../test_property_type.hpp"
-#include <simde/energy/total_energy.hpp>
+#include <simde/energy/energy.hpp>
 
 using namespace simde;
 
 TEST_CASE("TotalEnergy") {
     test_property_type<TotalEnergy>({"Chemical System"}, {"Energy"});
+}
+
+TEST_CASE("AOEnergy") {
+    test_property_type<AOEnergy>({"AOs", "Chemical System"}, {"Energy"});
+}
+
+TEST_CASE("ElectrostaticEnergy<charges, charges>") {
+    test_property_type<charge_charge_interaction>({"Objects", "Potential"},
+                                                  {"Energy"});
 }


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
This PR defines a new energy PT, `ElectrostaticEnergy` for modules which compute electrostatic interactions. The PT is templated on the type of the potential and the type of the objects which are interacting with the potential. Eventually we could have `charge_dipole`, `dipole_charge`, etc. versions.

**TODOs**
None. R2g.
