### PR TITLE
Overlap and Fock typedefs

### DIFF
--- a/include/simde/evaluate_braket/evaluate_braket.hpp
+++ b/include/simde/evaluate_braket/evaluate_braket.hpp
@@ -38,8 +38,12 @@ TEMPLATED_PROPERTY_TYPE_RESULTS(EvaluateBraKet, BraKetType) {
 
 #define EBK(bra, op, ket) EvaluateBraKet<type::braket<bra, op, ket>>
 
+using aos_s_e_aos  = EBK(type::aos, chemist::qm_operator::Identity, type::aos);
 using aos_t_e_aos  = EBK(type::aos, type::t_e_type, type::aos);
 using aos_v_en_aos = EBK(type::aos, type::v_en_type, type::aos);
+using aos_f_e_aos  = EBK(type::aos, type::fock, type::aos);
+using aos_j_e_aos  = EBK(type::aos, type::j_e_type, type::aos);
+using aos_k_e_aos  = EBK(type::aos, type::k_e_type, type::aos);
 
 // One electron density templated on the representation of the density operator
 template<typename OrbitalType>

--- a/include/simde/evaluate_braket/evaluate_braket.hpp
+++ b/include/simde/evaluate_braket/evaluate_braket.hpp
@@ -38,7 +38,7 @@ TEMPLATED_PROPERTY_TYPE_RESULTS(EvaluateBraKet, BraKetType) {
 
 #define EBK(bra, op, ket) EvaluateBraKet<type::braket<bra, op, ket>>
 
-using aos_s_e_aos  = EBK(type::aos, chemist::qm_operator::Identity, type::aos);
+using aos_s_e_aos  = EBK(type::aos, type::s_e_type, type::aos);
 using aos_t_e_aos  = EBK(type::aos, type::t_e_type, type::aos);
 using aos_v_en_aos = EBK(type::aos, type::v_en_type, type::aos);
 using aos_f_e_aos  = EBK(type::aos, type::fock, type::aos);


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
To be consistent with other operators this PR adds typedefs for the overlap operator, the Fock operator, the SCF Coulomb operator, and the SCF exchange operator.

**TODOs**
- [x] Merge https://github.com/NWChemEx/Chemist/pull/440
