### PR TITLE
Typedef for electronic Hamiltonian

### DIFF
--- a/include/simde/evaluate_braket/evaluate_braket.hpp
+++ b/include/simde/evaluate_braket/evaluate_braket.hpp
@@ -36,7 +36,10 @@ TEMPLATED_PROPERTY_TYPE_RESULTS(EvaluateBraKet, BraKetType) {
       "tensor representation");
 }
 
-#define EBK(bra, op, ket) EvaluateBraKet<type::braket<bra, op, ket>>
+template<typename BraType, typename OpType, typename KetType>
+using eval_braket = EvaluateBraKet<type::braket<BraType, OpType, KetType>>;
+
+#define EBK(bra, op, ket) eval_braket<bra, op, ket>
 
 using aos_op_base_aos = EBK(type::aos, type::op_base_type, type::aos);
 using aos_s_e_aos     = EBK(type::aos, type::s_e_type, type::aos);

--- a/include/simde/types.hpp
+++ b/include/simde/types.hpp
@@ -128,6 +128,9 @@ using hamiltonian = chemist::qm_operator::Hamiltonian;
 /// Pull in the CoreHamiltonian operator in case-consistent manner
 using core_hamiltonian = chemist::qm_operator::CoreHamiltonian;
 
+/// Pull in the ElectronicHamiltonian operator in case-consistent manner
+using electronic_hamiltonian = chemist::qm_operator::ElectronicHamiltonian;
+
 /// Pull in the Fock operator in case-consistent manner
 using fock = chemist::qm_operator::Fock;
 


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Title plus adds a typedef for `eval_braket` that can be used downstream when working out the PTs of modules via TMP.

**TODOs**
None. R2g.
