### PR TITLE
Swap scalars to tensors

### DIFF
--- a/include/simde/energy/electrostatic_energy.hpp
+++ b/include/simde/energy/electrostatic_energy.hpp
@@ -39,7 +39,8 @@ TEMPLATED_PROPERTY_TYPE_INPUTS(ElectrostaticEnergy, ObjectType, PotentialType) {
 template<typename ObjectType, typename PotentialType>
 TEMPLATED_PROPERTY_TYPE_RESULTS(ElectrostaticEnergy, ObjectType,
                                 PotentialType) {
-    auto rv = pluginplay::declare_result().add_field<double>("Energy");
+    auto rv =
+      pluginplay::declare_result().add_field<simde::type::tensor>("Energy");
     return rv;
 }
 

--- a/include/simde/energy/total_energy.hpp
+++ b/include/simde/energy/total_energy.hpp
@@ -40,7 +40,8 @@ PROPERTY_TYPE_INPUTS(TotalEnergy) {
 }
 
 PROPERTY_TYPE_RESULTS(TotalEnergy) {
-    auto rv = pluginplay::declare_result().add_field<double>("Energy");
+    auto rv =
+      pluginplay::declare_result().add_field<simde::type::tensor>("Energy");
     rv["Energy"].set_description("The computed energy");
     return rv;
 }


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
This swaps the return types of PTs like `Energy` so that they are `Tensor` instead of `double`. N.b., NWChemEx/Chemist#446 will take care of `EvalBraKet`.

**TODOs**
None. R2g.
