### PR TITLE
`aos_squared` is `std::pair`

### DIFF
--- a/include/simde/types.hpp
+++ b/include/simde/types.hpp
@@ -99,7 +99,7 @@ using braket = chemist::braket::BraKet<BraType, OpType, KetType>;
 using aos = chemist::wavefunction::AOs;
 
 /// Typedef of the class used to represent a product of atomic orbital spaces
-using aos_squared = utilities::dsl::Multiply<aos, aos>;
+using aos_squared = std::pair<aos, aos>;
 
 /// Typedef of the class used to represent transformed AOs
 using mos = chemist::wavefunction::MOs;


### PR DESCRIPTION
**Description**
As the DSL terms aren't meant to be long lasting, this PR changes the `aos_squared` type to a `std::pair` of `aos`.