### PR TITLE
Nuclear Geometry Optimization PTs

### DIFF
--- a/include/simde/optimize/optimize.hpp
+++ b/include/simde/optimize/optimize.hpp
@@ -15,40 +15,5 @@
  */
 
 #pragma once
-#include <pluginplay/pluginplay.hpp>
-
-namespace simde {
-
-/** @brief PT for algorithms which optimize quantities.
- *
- *  @tparam PropertyType The PT of the quantity being optimized. For a
- *                       conventional geometry optimization this would be
- *                       AOEnergy or TotalEnergy. For solving the SCF equations
- *                       it is something like ESCF<type::cmos>.
- *  @tparam WithRespectTo The type of the object being varied to optimize
- *                        @p PropertyType.
- *
- *  As the name implies, the Optimize property type is used by modules which
- *  optimize quantities. It is assumed that the quantity being optimized, i.e.,
- *  the objective function, can be computed by calling a submodule of property
- *  type @p PropertyType. The Optimize PT does NOT assume that quantity being
- *  optimized is a direct input to a module satisfying @p PropertyType, though
- *   it will be in many cases,
- */
-template<typename PropertyType, typename WithRespectTo>
-DECLARE_TEMPLATED_PROPERTY_TYPE(Optimize, PropertyType, WithRespectTo);
-
-template<typename PropertyType, typename WithRespectTo>
-TEMPLATED_PROPERTY_TYPE_INPUTS(Optimize, PropertyType, WithRespectTo) {
-    using input_type = const WithRespectTo&;
-    auto desc = "Object to optimize the objective function with respect to";
-    return PropertyType::inputs().template add_field<input_type>((desc));
-}
-
-template<typename PropertyType, typename WithRespectTo>
-TEMPLATED_PROPERTY_TYPE_RESULTS(Optimize, PropertyType, WithRespectTo) {
-    auto desc = "Object that optimizes the objective function";
-    return PropertyType::results().template add_field<WithRespectTo>(desc);
-}
-
-} // namespace simde
+#include <simde/optimize/optimize_energy.hpp>
+#include <simde/optimize/optimize_pt.hpp>

--- a/include/simde/optimize/optimize_energy.hpp
+++ b/include/simde/optimize/optimize_energy.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <chemist/chemist.hpp>
+#include <simde/energy/energy.hpp>
+#include <simde/optimize/optimize_pt.hpp>
+
+namespace simde {
+
+/** @brief Property type which optimizes another property type with respect to
+ *         nuclear positions.
+ *
+ *  @tparam PropertyType The property type whose value is being optimized.
+ */
+template<typename PropertType>
+using NuclearOptimization = Optimize<PropertType, chemist::PointSet<double>>;
+
+/** @brief Property type which optimizes total energy with respect to nuclear
+ *         positions.
+ */
+using TotalEnergyNuclearOptimization = NuclearOptimization<TotalEnergy>;
+
+/** @brief Property type which optimizes AO energy with respect to nuclear
+ *         positions.
+ */
+using AOEnergyNuclearOptimization = NuclearOptimization<AOEnergy>;
+
+}

--- a/include/simde/optimize/optimize_energy.hpp
+++ b/include/simde/optimize/optimize_energy.hpp
@@ -39,4 +39,4 @@ using TotalEnergyNuclearOptimization = NuclearOptimization<TotalEnergy>;
  */
 using AOEnergyNuclearOptimization = NuclearOptimization<AOEnergy>;
 
-}
+} // namespace simde

--- a/include/simde/optimize/optimize_pt.hpp
+++ b/include/simde/optimize/optimize_pt.hpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <pluginplay/pluginplay.hpp>
+
+namespace simde {
+
+/** @brief PT for algorithms which optimize quantities.
+ *
+ *  @tparam PropertyType The PT of the quantity being optimized. For a
+ *                       conventional geometry optimization this would be
+ *                       AOEnergy or TotalEnergy. For solving the SCF equations
+ *                       it is something like ESCF<type::cmos>.
+ *  @tparam WithRespectTo The type of the object being varied to optimize
+ *                        @p PropertyType.
+ *
+ *  As the name implies, the Optimize property type is used by modules which
+ *  optimize quantities. It is assumed that the quantity being optimized, i.e.,
+ *  the objective function, can be computed by calling a submodule of property
+ *  type @p PropertyType. The Optimize PT does NOT assume that quantity being
+ *  optimized is a direct input to a module satisfying @p PropertyType, though
+ *   it will be in many cases,
+ */
+template<typename PropertyType, typename WithRespectTo>
+DECLARE_TEMPLATED_PROPERTY_TYPE(Optimize, PropertyType, WithRespectTo);
+
+template<typename PropertyType, typename WithRespectTo>
+TEMPLATED_PROPERTY_TYPE_INPUTS(Optimize, PropertyType, WithRespectTo) {
+    using input_type = const WithRespectTo&;
+    auto desc = "Object to optimize the objective function with respect to";
+    return PropertyType::inputs().template add_field<input_type>((desc));
+}
+
+template<typename PropertyType, typename WithRespectTo>
+TEMPLATED_PROPERTY_TYPE_RESULTS(Optimize, PropertyType, WithRespectTo) {
+    auto desc = "Object that optimizes the objective function";
+    return PropertyType::results().template add_field<WithRespectTo>(desc);
+}
+
+} // namespace simde

--- a/src/python/optimize/export_optimize.hpp
+++ b/src/python/optimize/export_optimize.hpp
@@ -26,5 +26,7 @@ inline void export_optimize(python_module_reference m) {
       Optimize<ESCF<type::cmos>, type::rscf_wf>;
 
     EXPORT_PROPERTY_TYPE(OptimizeRSCFEnergyWRTRSCFWavefunction, m);
+    EXPORT_PROPERTY_TYPE(TotalEnergyNuclearOptimization, m);
+    EXPORT_PROPERTY_TYPE(AOEnergyNuclearOptimization, m);
 }
 } // namespace simde

--- a/tests/cxx/unit_tests/optimize/optimize_energy.cpp
+++ b/tests/cxx/unit_tests/optimize/optimize_energy.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../test_property_type.hpp"
+#include <simde/optimize/optimize_energy.hpp>
+
+using OptTotalEnergy = simde::TotalEnergyNuclearOptimization;
+using OptAOEnergy    = simde::AOEnergyNuclearOptimization;
+
+TEST_CASE("Energy Optimization Property Types") {
+    auto inp_desc = "Object to optimize the objective function with respect to";
+    auto out_desc = "Object that optimizes the objective function";
+    test_property_type<OptTotalEnergy>({"Chemical System", inp_desc},
+                                       {"Energy", out_desc});
+    test_property_type<OptAOEnergy>({"Chemical System", "AOs", inp_desc},
+                                    {"Energy", out_desc});
+}

--- a/tests/python/unit_tests/optimize/test_optimize.py
+++ b/tests/python/unit_tests/optimize/test_optimize.py
@@ -15,12 +15,29 @@
 import simde
 from test_property_type import BaseTestPropertyType
 
+inp_desc = 'Object to optimize the objective function with respect to'
+out_desc = 'Object that optimizes the objective function'
+
 
 class TestOptimizeRSCFEnergyWRTRSCFWavefunction(BaseTestPropertyType):
 
     def setUp(self):
         self.pt = simde.OptimizeRSCFEnergyWRTRSCFWavefunction()
-        inp_desc = 'Object to optimize the objective function with respect to'
-        out_desc = 'Object that optimizes the objective function'
         self.input_labels = ['BraKet', inp_desc]
         self.result_labels = ['tensor representation', out_desc]
+
+
+class TestTotalEnergyNuclearOptimization(BaseTestPropertyType):
+
+    def setUp(self):
+        self.pt = simde.TotalEnergyNuclearOptimization()
+        self.input_labels = ['Chemical System', inp_desc]
+        self.result_labels = ['Energy', out_desc]
+
+
+class TestAOEnergyNuclearOptimization(BaseTestPropertyType):
+
+    def setUp(self):
+        self.pt = simde.AOEnergyNuclearOptimization()
+        self.input_labels = ['Chemical System', 'AOs', inp_desc]
+        self.result_labels = ['Energy', out_desc]


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Defines property types for optimizing `AOEnergy` and `TotalEnergy` with respect to nuclear geometry, analogous to some of the derivative types.