### PR TITLE
Import Python Dependency

### DIFF
--- a/src/python/module.cpp
+++ b/src/python/module.cpp
@@ -30,6 +30,10 @@ namespace simde {
 PYBIND11_MODULE(simde, m) {
     m.doc() =
       "PySimDE: Python bindings for the Simulation development environment";
+
+    // Import dependencies
+    python_module_type::import("chemist");
+
     export_chemical_system(m);
     export_basis_set(m);
     export_energy(m);

--- a/tests/python/unit_tests/test_property_type.py
+++ b/tests/python/unit_tests/test_property_type.py
@@ -14,8 +14,6 @@
 
 import unittest
 
-import pluginplay as pp  # noqa F401, needed for inputs() and results()
-
 
 class BaseTestPropertyType(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
Follow up to NWChemEx/PluginPlay#371, adds the import of `chemist` to the `simde` python module to ensure the bindings for input and output types are being loaded. Also removes the `import pluginplay` hack from the unit tests now that `pluginplay` should be properly imported by in property type bindings.