### PR TITLE
Generalize collocation matrix

### DIFF
--- a/include/simde/integration_grids/collocation_matrix.hpp
+++ b/include/simde/integration_grids/collocation_matrix.hpp
@@ -21,20 +21,25 @@
 
 namespace simde {
 
-DECLARE_PROPERTY_TYPE(CollocationMatrix);
+template<typename QuantityToCollocate>
+DECLARE_TEMPLATED_PROPERTY_TYPE(CollocationMatrix, QuantityToCollocate);
 
-PROPERTY_TYPE_INPUTS(CollocationMatrix) {
-    using grid_type     = chemist::Grid;
-    using ao_basis_type = simde::type::ao_basis_set;
+template<typename QuantityToCollocate>
+TEMPLATED_PROPERTY_TYPE_INPUTS(CollocationMatrix, QuantityToCollocate) {
+    using grid_type = chemist::Grid;
     return pluginplay::declare_input()
       .add_field<grid_type>("Grid")
-      .add_field<const ao_basis_type&>("AO Basis Set");
+      .add_field<const QuantityToCollocate&>("Quantity to Collocate");
 }
 
-PROPERTY_TYPE_RESULTS(CollocationMatrix) {
+template<typename QuantityToCollocate>
+TEMPLATED_PROPERTY_TYPE_RESULTS(CollocationMatrix, QuantityToCollocate) {
     using result_type = simde::type::tensor;
     return pluginplay::declare_result().add_field<result_type>(
       "Collocation Matrix");
 }
+
+using AOCollocationMatrix       = CollocationMatrix<simde::type::ao_basis_set>;
+using EDensityCollocationMatrix = CollocationMatrix<simde::type::e_density>;
 
 } // namespace simde

--- a/tests/cxx/unit_tests/integration_grids/collocation_matrix.cpp
+++ b/tests/cxx/unit_tests/integration_grids/collocation_matrix.cpp
@@ -17,9 +17,10 @@
 #include "../test_property_type.hpp"
 #include <simde/integration_grids/collocation_matrix.hpp>
 
-using property_type = simde::CollocationMatrix;
+using property_types =
+  std::tuple<simde::AOCollocationMatrix, simde::EDensityCollocationMatrix>;
 
-TEST_CASE("CollocationMatrix") {
-    test_property_type<property_type>({"Grid", "AO Basis Set"},
-                                      {"Collocation Matrix"});
+TEMPLATE_LIST_TEST_CASE("CollocationMatrix", "", property_types) {
+    test_property_type<TestType>({"Grid", "Quantity to Collocate"},
+                                 {"Collocation Matrix"});
 }


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
My understanding is that a "collocation matrix" is a matrix where one mode is spanned by grid points and the other mode is spanned by one or more functions evaluated at those grid points. The original PT assumed the functions were AOs. This PR generalizes it to arbitrary quantities so that it can be used to form the collocation matrix for the AO density (among other things).

**TODOs**
- [ ] Merge https://github.com/NWChemEx/SCF/pull/48 (which uses the old PT)
