### PR TITLE
adds a pt for normal eigensolve

### DIFF
--- a/include/simde/numerical_methods/eigen_solve.hpp
+++ b/include/simde/numerical_methods/eigen_solve.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <pluginplay/property_type/property_type.hpp>
+#include <simde/types.hpp>
+
+namespace simde {
+
+DECLARE_PROPERTY_TYPE(EigenSolve);
+
+PROPERTY_TYPE_INPUTS(EigenSolve) {
+    using input_type = const type::tensor&;
+    auto rv = pluginplay::declare_input().add_field<input_type>("Matrix");
+    rv["Matrix"].set_description("The matrix to diagonalize.");
+    return rv;
+}
+
+PROPERTY_TYPE_RESULTS(EigenSolve) {
+    using result_type = type::tensor;
+    auto rv           = pluginplay::declare_result()
+                .add_field<result_type>("Eigen values")
+                .template add_field<result_type>("Eigen vectors");
+    return rv;
+}
+
+} // namespace simde

--- a/include/simde/numerical_methods/numerical_methods.hpp
+++ b/include/simde/numerical_methods/numerical_methods.hpp
@@ -16,4 +16,5 @@
 
 #pragma once
 
+#include <simde/numerical_methods/eigen_solve.hpp>
 #include <simde/numerical_methods/generalized_eigen_solve.hpp>

--- a/tests/cxx/unit_tests/numerical_methods/numerical_methods.cpp
+++ b/tests/cxx/unit_tests/numerical_methods/numerical_methods.cpp
@@ -19,6 +19,11 @@
 
 using namespace simde;
 
+TEST_CASE("EigenSolve") {
+    test_property_type<EigenSolve>({"Matrix"},
+                                   {"Eigen values", "Eigen vectors"});
+}
+
 TEST_CASE("GeneralizedEigenSolve") {
     test_property_type<GeneralizedEigenSolve>(
       {"Matrix", "Metric"}, {"Eigen values", "Eigen vectors"});


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
We had a property type for solving a generalized eigensystem equation, but not one for solving a "normal" eigensystem. This PR fixes that.

**TODOs**
R2g.
